### PR TITLE
fix: update readme example with code from QuickStart_Map_Simple

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ See [QuickStart.java](/src/main/java/quickstart/QuickStart_Map_Simple.java).
 
 ```java
 Map<Integer, Integer, Void> map =
-  MapConfig
+  MemoryMap
     .functionsOff(intSerializer(), intSerializer())
     .get();
 
@@ -35,15 +35,15 @@ map.expire(1, Duration.ofSeconds(1)); //basic expire
 map.remove(1); //basic remove
 
 //atomic write a Stream of key-value
-map.put(Stream.range(1, 100).map(KeyVal::create));
+map.put(Stream.range(1, 100).map(KeyVal::of));
 
 //Create a stream that updates all values within range 10 to 90.
 Stream<KeyVal<Integer, Integer>> updatedKeyValues =
   map
-    .from(10)
     .stream()
+    .from(10)
     .takeWhile(keyVal -> keyVal.key() <= 90)
-    .map(keyVal -> KeyVal.create(keyVal.key(), keyVal.value() + 5000000));
+    .map(keyVal -> KeyVal.of(keyVal.key(), keyVal.value() + 5000000));
 
 //submit the stream to update the key-values as a single transaction.
 map.put(updatedKeyValues);


### PR DESCRIPTION
Update readme example with code from QuickStart_Map_Simple

Seems like `MemoryMap` should be used instead of `MapConfig`.